### PR TITLE
Add always arrow parens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
     "name": "@trojs/lint",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@trojs/lint",
-            "version": "0.2.4",
+            "version": "0.2.5",
             "license": "MIT",
             "dependencies": {
-                "@eslint/js": "^9.19.0",
                 "@stylistic/eslint-plugin": "^3.0.1",
                 "@stylistic/eslint-plugin-js": "^3.0.1",
                 "eslint": "^9.19.0",
@@ -21,6 +20,7 @@
                 "globals": "^15.14.0"
             },
             "devDependencies": {
+                "@eslint/js": "^9.19.0",
                 "@types/node": "^22.12.0",
                 "c8": "^10.1.3",
                 "jscpd": "^4.0.5"
@@ -3226,9 +3226,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.91",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
-            "integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
+            "version": "1.5.92",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.92.tgz",
+            "integrity": "sha512-BeHgmNobs05N1HMmMZ7YIuHfYBGlq/UmvlsTgg+fsbFs9xVMj+xJHFg19GN04+9Q+r8Xnh9LXqaYIyEWElnNgQ==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -3249,9 +3249,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
-            "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
+            "version": "5.18.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+            "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -4418,12 +4418,12 @@
             }
         },
         "node_modules/is-boolean-object": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-            "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+            "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
             "license": "MIT",
             "dependencies": {
-                "call-bound": "^1.0.2",
+                "call-bound": "^1.0.3",
                 "has-tostringtag": "^1.0.2"
             },
             "engines": {
@@ -5233,9 +5233,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-            "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trojs/lint",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "description": "Lint rules",
     "type": "module",
     "main": "src/index.js",
@@ -42,7 +42,6 @@
     },
     "homepage": "https://github.com/trojs/lint#readme",
     "dependencies": {
-        "@eslint/js": "^9.19.0",
         "@stylistic/eslint-plugin": "^3.0.1",
         "@stylistic/eslint-plugin-js": "^3.0.1",
         "eslint": "^9.19.0",
@@ -54,6 +53,7 @@
         "globals": "^15.14.0"
     },
     "devDependencies": {
+        "@eslint/js": "^9.19.0",
         "@types/node": "^22.12.0",
         "c8": "^10.1.3",
         "jscpd": "^4.0.5"

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ const plugins = {
   jsdoc: jsdocPlugin,
   n: nodePlugin,
   promise: promisePlugin,
-  sonarjs: sonarjsPlugin
+  sonarjs: sonarjsPlugin,
+  js: pluginJs
 }
 export { rules, plugins, eslintConfig as default }

--- a/src/rules/stylistic.js
+++ b/src/rules/stylistic.js
@@ -12,5 +12,9 @@ export default {
   '@stylistic/quote-props': [
     'error',
     'as-needed'
+  ],
+  '@stylistic/arrow-parens': [
+    'error',
+    'always'
   ]
 }


### PR DESCRIPTION
Compatible with old standardjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the application version from 0.2.4 to 0.2.5.
  - Reorganized a linting-related dependency from runtime to development.

- **New Features**
  - Enhanced linting configuration with a new JavaScript plugin.
  - Added a stylistic rule to enforce consistent use of parentheses in arrow functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->